### PR TITLE
Update Shopify.php

### DIFF
--- a/shopify.php
+++ b/shopify.php
@@ -94,7 +94,10 @@ class ShopifyClient {
 		
 		$string = implode("&", $dataString);
 
-		$signatureBin = mhash(MHASH_SHA256, $string, $this->secret);
+		if (version_compare(PHP_VERSION, '5.3.0', '>='))
+			$signatureBin = hash_hmac('sha256', $string, $this->secret);
+		    else
+			$signatureBin = mhash(MHASH_SHA256, $string, $this->secret);
 		$signature = bin2hex($signatureBin);
 		
 		return $query['hmac'] == $signature;


### PR DESCRIPTION
Make compatible for versions of PHP greater and equal to 5.3.

mhash is depreciated as of version 5.3. Use 'hash_hmac' function instead.